### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -14,6 +14,9 @@ test("assign()", () => {
   expect(assign(operand, "/b/c", "Hello, world!")).toBe(false);
   expect(deref(operand, "/b/c")).toBeUndefined();
   expect(operand.b).toBeUndefined();
+
+  expect(assign(operand, '/__proto__/polluted', true)).toBe(false);
+  expect(Object.keys(Object.prototype).includes('polluted')).toBe(false);
 });
 
 test("deref()", () => {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,5 +1,5 @@
 import * as cache from "./cache";
-import { compile, parse } from "./token";
+import { compile, parse, disallowProtoPath } from "./token";
 
 export { compile, parse };
 
@@ -33,7 +33,7 @@ export interface Operand {
  * ```
  */
 export function assign(operand: Operand, pointer: string, value: any): boolean {
-  const tokens = [...parse(pointer)];
+  const tokens = disallowProtoPath([...parse(pointer)]);
   const lastToken = tokens.pop();
   const parentValue = deref(operand, compile(tokens));
 

--- a/src/token.ts
+++ b/src/token.ts
@@ -75,3 +75,17 @@ export function unescape(token: string): string {
       return token.replace(ESCAPED, unescape);
   }
 }
+
+/**
+ * Blacklist dangerous Tokens to prevent Prototype Pollution vulnerability
+ */
+ export function disallowProtoPath(tokens: string[]): string[] {
+  const isTokenBlackListed = tokens.findIndex((key) => 
+    ['__proto__', 'constructor', 'prototype'].includes(key));
+
+  if (isTokenBlackListed == -1) {
+    return tokens;
+  } else {
+    return [];
+  }
+}


### PR DESCRIPTION
### :bar_chart: Metadata *

`@zakgolba/jsonptr` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40zakgolba%2Fjsonptr

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```javascript
// poc.js
const { assign } = require('@zakgolba/jsonptr')

console.log('Before: ' + {}.polluted)
assign({}, '/__proto__/polluted', true)
console.log('After: ' + {}.polluted)
```
2. Execute the following commands in terminal:
```bash
npm i @zakgolba/jsonptr # Install affected package
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : true
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/111909436-49e49c80-8a83-11eb-91be-b880a2afa5f3.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
